### PR TITLE
fix motion detection for larger framesizes

### DIFF
--- a/src/ImageProcessing/DownscaleStrategies/Core.h
+++ b/src/ImageProcessing/DownscaleStrategies/Core.h
@@ -31,14 +31,19 @@ namespace Eloquent {
                      * @param block
                      * @return
                      */
-                    const uint8_t apply(uint8_t block[sourceHeight / destHeight][sourceWidth / destWidth]) {
-                        const uint8_t centerX = sourceWidth / destWidth * 0.5;
-                        const uint8_t centerY = sourceHeight / destHeight * 0.5;
+                    const uint8_t apply(uint8_t block[sourceHeight / destHeight][sourceWidth / destWidth])
+                    {
+                        const uint8_t blockSizeX = sourceWidth / destWidth;
+                        const uint8_t blockSizeY = sourceHeight / destHeight;
+                        const uint8_t centerX = blockSizeX * 0.5;
+                        const uint8_t centerY = blockSizeY * 0.5;
                         uint16_t accumulator = 0;
                         uint8_t count = 0;
 
-                        for (uint8_t y = max(0, centerY - _radius); y < centerY + _radius; y++) {
-                            for (uint8_t x = max(0, centerX - _radius); x < centerX + _radius; x++) {
+                        for (uint8_t y = max(0, centerY - _radius); y < min(centerY + _radius, (int)blockSizeY); y++)
+                        {
+                            for (uint8_t x = max(0, centerX - _radius); x < min(centerX + _radius, (int)blockSizeX); x++)
+                            {
                                 accumulator += block[y][x];
                                 count += 1;
                             }

--- a/src/ImageProcessing/MotionDetection.h
+++ b/src/ImageProcessing/MotionDetection.h
@@ -155,7 +155,7 @@ namespace Eloquent {
             /**
              * Cache number of changes
              */
-            uint8_t _changes;
+            uint16_t _changes;
         };
     }
 }


### PR DESCRIPTION
cfbef7b keeps `_changes` from overflowing if the number of pixels that change is >255, especially with larger frame sizes

62bc43e checks for array out of bounds on the other end of the array in core downscaling.

not sure what format you want so I used semantic commit messages. lmk if you prefer otherwise or need any edits.

thanks for making this library!